### PR TITLE
Move post_logout_redirect_uri into client_options

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -21,7 +21,7 @@ module OmniAuth
         token_endpoint: '/token',
         userinfo_endpoint: '/userinfo',
         jwks_uri: '/jwk',
-        end_session_endpoint: nil,
+        end_session_endpoint: '/logout',
         post_logout_redirect_uri: nil
       }
       option :issuer

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -21,7 +21,8 @@ module OmniAuth
         token_endpoint: '/token',
         userinfo_endpoint: '/userinfo',
         jwks_uri: '/jwk',
-        end_session_endpoint: nil
+        end_session_endpoint: nil,
+        post_logout_redirect_uri: nil
       }
       option :issuer
       option :discovery, false
@@ -42,7 +43,6 @@ module OmniAuth
       option :send_nonce, true
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
-      option :post_logout_redirect_uri
 
       uid { user_info.sub }
 
@@ -259,9 +259,9 @@ module OmniAuth
       end
 
       def encoded_post_logout_redirect_uri
-        return unless options.post_logout_redirect_uri
+        return unless client_options.post_logout_redirect_uri
         URI.encode_www_form(
-          post_logout_redirect_uri: options.post_logout_redirect_uri
+          post_logout_redirect_uri: client_options.post_logout_redirect_uri
         )
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -45,7 +45,7 @@ module OmniAuth
         expected_redirect = 'https://example.com/logout?post_logout_redirect_uri=https%3A%2F%2Fmysite.com'
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
-        strategy.options.post_logout_redirect_uri = 'https://mysite.com'
+        strategy.options.client_options.post_logout_redirect_uri = 'https://mysite.com'
 
         issuer = stub('OpenIDConnect::Discovery::Issuer')
         issuer.stubs(:issuer).returns('https://example.com/')


### PR DESCRIPTION
Hi!

Thank you for keeping this gem alive and many thanks for adding logout support.

I think the `: post_logout_redirect_uri` option should be part of the `client_options` along with the `redirect_uri`.

In addition, it would be nice to have some documentation about the new options in the README.

What do you think?
