### PR TITLE
add-application-domain-to-possible-request-params

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -141,6 +141,7 @@ module OmniAuth
           prompt: request.params['prompt'],
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
+          application_domain: request.params['application_domain']
         }
         client.authorization_uri(opts.reject { |k, v| v.nil? })
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -85,6 +85,16 @@ module OmniAuth
         strategy.request_phase
       end
 
+      def test_request_phase_with_application_domain_param
+        expected_redirect = /^https:\/\/example\.com\/authorize\?application_domain=test.example.com&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
+        strategy.options.issuer = 'example.com'
+        strategy.options.client_options.host = 'example.com'
+        request.stubs(:params).returns('application_domain' => 'test.example.com')
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+      end
+
       def test_request_phase_with_discovery
         expected_redirect = /^https:\/\/example\.com\/authorization\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.client_options.host = 'example.com'


### PR DESCRIPTION
It allow us to send an `application_domain` param.
It works like Google's hd param: https://developers.google.com/identity/protocols/OpenIDConnect#hd-param
