### PR TITLE
Rename application_domain to ad

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -141,7 +141,7 @@ module OmniAuth
           prompt: request.params['prompt'],
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
-          application_domain: request.params['application_domain']
+          ad: request.params['ad']
         }
         client.authorization_uri(opts.reject { |k, v| v.nil? })
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -85,11 +85,11 @@ module OmniAuth
         strategy.request_phase
       end
 
-      def test_request_phase_with_application_domain_param
-        expected_redirect = /^https:\/\/example\.com\/authorize\?application_domain=test.example.com&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
+      def test_request_phase_with_ad_param
+        expected_redirect = /^https:\/\/example\.com\/authorize\?ad=test.example.com&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
-        request.stubs(:params).returns('application_domain' => 'test.example.com')
+        request.stubs(:params).returns('ad' => 'test.example.com')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase


### PR DESCRIPTION
Renaming `application_domain` to `ad`, it will help reduce the url size