### PR TITLE
Add organization_domain to authorized params

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -141,7 +141,9 @@ module OmniAuth
           prompt: request.params['prompt'],
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
-          ad: request.params['ad']
+          # TODO: Remove ad params once the apps have all switched to organization_domain
+          ad: request.params['ad'],
+          organization_domain: request.params['organization_domain']
         }
         client.authorization_uri(opts.reject { |k, v| v.nil? })
       end

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '~> 1.3'
   spec.add_dependency 'openid_connect', '~> 1.1.6'
   spec.add_dependency 'addressable', '~> 2.5'
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'minitest', '~> 5.1'
   spec.add_development_dependency 'mocha', '~> 1.2'
   spec.add_development_dependency 'guard', '~> 2.14'

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -85,11 +85,22 @@ module OmniAuth
         strategy.request_phase
       end
 
+      # TODO: Remove this when all the apps have switched to organization_domain
       def test_request_phase_with_ad_param
         expected_redirect = /^https:\/\/example\.com\/authorize\?ad=test.example.com&client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
         request.stubs(:params).returns('ad' => 'test.example.com')
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+      end
+
+      def test_request_phase_with_organization_domain_param
+        expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&nonce=\w{32}&organization_domain=test.example.com&response_type=code&scope=openid&state=\w{32}$/
+        strategy.options.issuer = 'example.com'
+        strategy.options.client_options.host = 'example.com'
+        request.stubs(:params).returns('organization_domain' => 'test.example.com')
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase


### PR DESCRIPTION
Add `organization_domain` param that will soon replace ad param, but keeping the `ad` param for compatibility reasons

I also had to update `bundler` because it seems that travis is now using `2.0.1` (and my computer too)