### PR TITLE
options accepts a list of custom params for auth phase

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -44,6 +44,7 @@ module OmniAuth
       option :send_scope_to_token_endpoint, true
       option :client_auth_method
       option :post_logout_redirect_uri
+      option :optional_params, []
 
       uid { user_info.sub }
 
@@ -146,6 +147,9 @@ module OmniAuth
           hd: options.hd,
           organization_domain: request.params['organization_domain']
         }
+        options.optional_params.each do |key|
+          opts[key] = request.params[key.to_s] unless options.optional_params.empty?
+        end
         client.authorization_uri(opts.reject { |k, v| v.nil? })
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -143,6 +143,17 @@ module OmniAuth
         strategy.request_phase
       end
 
+      def test_request_phase_with_optional_params
+        expected_redirect = /^https:\/\/example\.com\/authorize\?client_id=1234&logo=example_logo&name=example&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
+        strategy.options.issuer = 'example.com'
+        strategy.options.optional_params = [:name, :logo]
+        strategy.options.client_options.host = 'example.com'
+        request.stubs(:params).returns('name' => 'example', 'logo' => 'example_logo')
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+      end
+
       def test_request_phase_with_discovery
         expected_redirect = /^https:\/\/example\.com\/authorization\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$/
         strategy.options.client_options.host = 'example.com'


### PR DESCRIPTION
Add `extra_authorize_params` option, that list allowed parameters to be sent during authorize phase.
